### PR TITLE
Bump dask 0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
 install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy cython setuptools
-  - conda install -q -n test-environment dask=0.14.2 || true
+  - conda install -q -n test-environment dask=0.15.0 || true
   - source activate test-environment
   - python setup.py -v build_ext --inplace
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ it is not tested against them.
 Optional Dependencies
 ---------------------
 - Scipy_ >= 0.16
-- Dask_ >= 0.14.2
+- Dask_ >= 0.15.0
 
 Scipy and Dask are only required in order to use their respective interfaces.
 

--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,10 +236,18 @@ else:
     del scipy
     from . import scipy_fftpack
 
-try:
-    from dask.array.fft import fft_wrap
-except ImportError:
-    pass
-else:
-    del fft_wrap
+from distutils.version import LooseVersion
+import numpy
+
+fft_wrap = None
+if LooseVersion(numpy.__version__) > LooseVersion("1.10"):
+    try:
+        from dask.array.fft import fft_wrap
+    except ImportError:
+        pass
+del LooseVersion
+del numpy
+
+if fft_wrap:
     from . import dask_fft
+del fft_wrap

--- a/pyfftw/interfaces/dask_fft.py
+++ b/pyfftw/interfaces/dask_fft.py
@@ -56,6 +56,10 @@ which this may not be true.
 from . import numpy_fft as _numpy_fft
 from dask.array.fft import (
     fft_wrap,
+    fftfreq,
+    rfftfreq,
+    fftshift,
+    ifftshift,
 )
 
 fft = fft_wrap(_numpy_fft.fft)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 numpy>=1.6
 scipy>=0.12.0
-dask>=0.14.2
+dask>=0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 numpy>=1.6
 scipy>=0.12.0
-dask>=0.15.0
+dask[array]>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -759,6 +759,10 @@ def setup_package():
 
     install_requires = [numpy_requirement]
 
+    opt_requires = {
+        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0']
+    }
+
     setup_args = {
         'name': 'pyFFTW',
         'version': versioneer.get_version(),
@@ -786,6 +790,7 @@ def setup_package():
     if using_setuptools:
         setup_args['setup_requires'] = build_requires
         setup_args['install_requires'] = install_requires
+        setup_args['extras_require'] = opt_requires
 
     if len(sys.argv) >= 2 and (
         '--help' in sys.argv[1:] or

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -47,13 +47,14 @@ from distutils.version import LooseVersion
 import unittest
 import numpy
 
-try:
+if interfaces.dask_fft:
     import dask.array as da
     from dask.array import fft as da_fft
     from dask.array.fft import fft_wrap
-except ImportError:
+else:
     da = None
     da_fft = None
+    fft_wrap = None
 
 import warnings
 import copy

--- a/test/test_pyfftw_dask_interface.py
+++ b/test/test_pyfftw_dask_interface.py
@@ -92,7 +92,7 @@ functions = {
         'hfft': 'c2r',
         'ihfft': 'r2c'}
 
-acquired_names = ('fft_wrap',)
+acquired_names = ('fft_wrap', 'fftfreq', 'rfftfreq', 'fftshift', 'ifftshift')
 
 @unittest.skipIf(
     not interfaces.dask_fft,


### PR DESCRIPTION
Resolves conflicts with `pyFFTW/master` and bumps the Dask requirement to 0.15.0.