### PR TITLE
Relax Dask constraints

### DIFF
--- a/pyfftw/interfaces/__init__.py
+++ b/pyfftw/interfaces/__init__.py
@@ -236,18 +236,10 @@ else:
     del scipy
     from . import scipy_fftpack
 
-from distutils.version import LooseVersion
-import numpy
-
-fft_wrap = None
-if LooseVersion(numpy.__version__) > LooseVersion("1.10"):
-    try:
-        from dask.array.fft import fft_wrap
-    except ImportError:
-        pass
-del LooseVersion
-del numpy
-
-if fft_wrap:
+try:
+    from dask.array.fft import fft_wrap
+except ImportError:
+    pass
+else:
+    del fft_wrap
     from . import dask_fft
-del fft_wrap

--- a/setup.py
+++ b/setup.py
@@ -760,7 +760,7 @@ def setup_package():
     install_requires = [numpy_requirement]
 
     opt_requires = {
-        'dask': ['numpy>=1.10, <2.0', 'dask[array]>=0.15.0']
+        'dask': ['dask[array]>=0.15.0']
     }
 
     setup_args = {


### PR DESCRIPTION
If we are to require NumPy 1.10, there is no need for Dask to also specify this requirement. Further there is no need for a specialized NumPy version check before importing Dask as it already meets the minimum requirements.